### PR TITLE
Added requirement for cargo-generate in Tutorial

### DIFF
--- a/content/tutorials/firstmod/index.md
+++ b/content/tutorials/firstmod/index.md
@@ -32,6 +32,7 @@ You'll need to have a few things ready before you can do this tutorial:
 
 * **waxosuit** - Eventually you'll want this installed, but for now you can just use the docker image.
 * **wascap** - you will need the [wascap](https://github.com/waxosuit/wascap) tool installed (`cargo install wascap --features "cli"`). This is used to sign and verify WebAssembly modules.
+* **cargo generate** - you will need the [cargo-generate crate](https://crates.io/crates/cargo-generate) installed (`cargo install cargo-generate`) to create a project from the waxosuit-guest-template
 
 <a name="create"></a>
 


### PR DESCRIPTION
In the "Your First Module" repository, you need cargo-generate installed to run `cargo generate --git https://github.com/waxosuit/waxosuit-guest-template`